### PR TITLE
changes due to xcm benchmarking (mostly)

### DIFF
--- a/examples/statemine/xcm/1_dmp.yml
+++ b/examples/statemine/xcm/1_dmp.yml
@@ -77,7 +77,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 4,000,000,000
+                        value: 1,015,543,000
               - queries:
                   balance_rc_sender_after:
                     chain: *relay_chain
@@ -148,7 +148,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        value: 1,016,375,000
               - queries:
                   forced_created_asset:
                     chain: *assets_parachain
@@ -215,8 +215,8 @@ tests:
                       chain: *assets_parachain
                       attribute:
                         type: XcmV2TraitsOutcome
-                        isIncomplete: true
-                        value: ['1,000,000,000' , UntrustedReserveLocation]
+                        isError: true
+                        value: "WeightNotComputable"
               - queries:
                   balance_rc_sender_after:
                     chain: *relay_chain

--- a/examples/statemine/xcm/2_ump.yml
+++ b/examples/statemine/xcm/2_ump.yml
@@ -62,7 +62,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 4,000,000,000
+                        value: 1,015,543,000
 
           - name: Get the balances of the Assets Parachain's sender & Relay Chain's receiver
             actions:
@@ -97,7 +97,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        value: 354,190,000
                     - name: ump.ExecutedUpward
                       chain: *relay_chain
                       attribute:

--- a/examples/statemine/xcm/3_hrmp-open-channels.yml
+++ b/examples/statemine/xcm/3_hrmp-open-channels.yml
@@ -259,7 +259,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        value: 1,016,375,000
                     - name: polkadotXcm.Sent
                       chain: *assets_parachain
                     - name: ump.ExecutedUpward
@@ -324,7 +324,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        value: 1,016,375,000
                     - name: polkadotXcm.Sent
                       chain: *assets_parachain
                     - name: ump.ExecutedUpward

--- a/examples/statemine/xcm/4_hrmp.yml
+++ b/examples/statemine/xcm/4_hrmp.yml
@@ -87,7 +87,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        value: 1,016,375,000
               - queries:
                   forced_created_asset:
                     chain: *assets_parachain
@@ -168,7 +168,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 1,000,000,000
+                        value: 649,386,000
                     - name: assets.Transferred
                       attribute:
                         type: AccountId32
@@ -215,7 +215,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 1,000,000,000
+                        value: 649,386,000
                     - name: balances.Endowed
                       attribute:
                         type: AccountId32

--- a/examples/statemint/xcm/1_dmp.yml
+++ b/examples/statemint/xcm/1_dmp.yml
@@ -77,7 +77,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 4,000,000,000
+                        value: 1,022,566,000
               - queries:
                   balance_rc_sender_after:
                     chain: *relay_chain
@@ -148,7 +148,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        value: 1,020,265,000
               - queries:
                   forced_created_asset:
                     chain: *assets_parachain
@@ -215,8 +215,8 @@ tests:
                       chain: *assets_parachain
                       attribute:
                         type: XcmV2TraitsOutcome
-                        isIncomplete: true
-                        value: ['1,000,000,000' , UntrustedReserveLocation]
+                        isError: true
+                        value: "WeightNotComputable"
               - queries:
                   balance_rc_sender_after:
                     chain: *relay_chain

--- a/examples/statemint/xcm/2_ump.yml
+++ b/examples/statemint/xcm/2_ump.yml
@@ -62,7 +62,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 4,000,000,000
+                        value: 1,022,566,000
 
           - name: Get the balances of the Assets Parachain's sender & Relay Chain's receiver
             actions:
@@ -98,7 +98,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        value: 359,002,000
                     - name: ump.ExecutedUpward
                       chain: *relay_chain
                       attribute:

--- a/examples/statemint/xcm/3_hrmp-open-channels.yml
+++ b/examples/statemint/xcm/3_hrmp-open-channels.yml
@@ -257,7 +257,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        value: 1,020,265,000
                     - name: polkadotXcm.Sent
                       chain: *assets_parachain
                     - name: ump.ExecutedUpward
@@ -322,7 +322,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        value: 1,020,265,000
                     - name: polkadotXcm.Sent
                       chain: *assets_parachain
                     - name: ump.ExecutedUpward

--- a/examples/statemint/xcm/4_hrmp.yml
+++ b/examples/statemint/xcm/4_hrmp.yml
@@ -87,7 +87,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        value: 1,020,265,000
               - queries:
                   forced_created_asset:
                     chain: *assets_parachain
@@ -167,7 +167,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 1,000,000,000
+                        value: 655,068,000
                     - name: assets.Transferred
                       attribute:
                         type: AccountId32
@@ -214,7 +214,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 1,000,000,000
+                        value: 655,068,000
                     - name: balances.Endowed
                       attribute:
                         type: AccountId32


### PR DESCRIPTION
This is an updated PR from https://github.com/paritytech/cumulus/pull/1650
- nachopal was right - using the latest version caused some of those problems to go away.
