### PR TITLE
Support selection of nested value within query result

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,8 @@ interface Query {
   pallet: string;
   call: string;
   args: any[];
+  // An optional path used to select a nested value within a query result.
+  selector?: string
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ interface Query {
   pallet: string;
   call: string;
   args: any[];
-  // An optional path used to select a nested value within a query result.
+  // An optional path used to select a nested value within a query result (https://lodash.com/docs/#get).
   selector?: string
 }
 ```

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -41,6 +41,8 @@ export interface Query {
   pallet: string;
   call: string;
   args: any[];
+  // An optional path used to select a nested value within a query result.
+  selector?: string
 }
 
 export interface Rpc {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { Query } from './interfaces';
 import { parseArgs, sleep } from './utils';
 
@@ -40,8 +41,17 @@ export const sendQuery = async (context, key: string, query: Query) => {
   let parsedArgs = parseArgs(context, args);
   await sleep(delay ? delay : context.actionDelay);
   let result = await api.query[pallet][call](...parsedArgs);
+  if (result && query.selector)
+    result = get(result, query.selector);
   return result;
 };
+
+const get = (object, path: string): any => {
+  object = _.get(object, path);
+  if (_.isNil(object)) return object;
+  if (object.__UIntType) return BigInt(object);
+  return object;
+}
 
 export const queriesBuilder = async (
   context,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -136,7 +136,7 @@ export const parseArgs = (context, args): any[] => {
         let replacement = variables[keys[i]];
         if (typeof replacement === 'string') {
           strigifiedArg = strigifiedArg.replace(regex, `"${replacement}"`);
-        } else if (typeof replacement === 'number') {
+        } else if (typeof replacement === 'number' || typeof replacement === 'bigint') {
           strigifiedArg = strigifiedArg.replace(regex, `${replacement}`);
         } else if (typeof replacement === 'object') {
           strigifiedArg = strigifiedArg.replace(

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -1,0 +1,45 @@
+[settings]
+timeout = 1000
+
+[relaychain]
+chain = "rococo-local"
+default_command = "./bin/polkadot"
+
+[[relaychain.nodes]]
+name = "alice"
+validator = true
+ws_port = 9900
+extra_args = [ "-lparachain=debug" ]
+
+[[relaychain.nodes]]
+name = "bob"
+validator = true
+extra_args = [ "-lparachain=debug" ]
+
+[[relaychain.nodes]]
+name = "charlie"
+validator = true
+extra_args = [ "-lparachain=debug" ]
+
+[[parachains]]
+id = 1000
+add_to_genesis = true
+cumulus_based = true
+chain = "statemine-local"
+
+[[parachains.collators]]
+name = "statemine-collator01"
+command = "./bin/polkadot-parachain"
+ws_port = 9910
+args = ["--log=xcm=trace,pallet-assets=trace"]
+
+[[parachains.collators]]
+name = "statemine-collator02"
+command = "./bin/polkadot-parachain"
+ws_port = 9911
+args = ["--log=xcm=trace,pallet-assets=trace"]
+
+[types.Header]
+number = "u64"
+parent_hash = "Hash"
+post_state = "Hash"

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -1,0 +1,28 @@
+---
+settings:
+  chains:
+    relay_chain: &relay_chain
+      wsPort: 9900
+  variables:
+    chains:
+      relay_chain:
+        alice_account: &account 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+  decodedCalls: {}
+
+tests:
+  - name: Tests
+    describes:
+      - name: Query tests
+        its:
+          - name: Query selector should return nested value
+            actions:
+              - queries:
+                  balance:
+                    chain: *relay_chain
+                    pallet: system
+                    call: account
+                    args: [ *account ]
+                    selector: 'data.free'
+              - asserts:
+                  equal:
+                    args: [ $balance, 1000000000000000000 ]


### PR DESCRIPTION
- adds support for selection of nested value within query result, auto-converting balance values accordingly (bigint)
  - isolates change to a single function
- added simple test to ensure functionality works as expected, useful for regression testing. e.g. `yarn zombienet-test -t tests -c tests/config.toml`
- updated interface in readme

Example usage (from test.yml):
```
              - queries:
                  balance:
                    chain: *relay_chain
                    pallet: system
                    call: account
                    args: [ *account ]
                    selector: 'data.free'
              - asserts:
                  equal:
                    args: [ $balance, 1000000000000000000 ]
```