### PR TITLE
Support multiple asserts of same type

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ export type RpcAction = {
 }
 
 export type AssertAction = {
-  asserts: { [key: string]: AssertOrCustom };
+  asserts: AssertOrCustom[];
 }
 
 export type CustomAction = {
@@ -703,18 +703,18 @@ tests: # Describe[]
       - name: Should reduce the balance of the sender
         actions: # Action[]
           - asserts: # { [key: string]: AssertOrCustom }
-              customs:
-                path: ./asserts/checkSenderBalances.ts
-                args:
-                  {
-                    balances: {
-                      before: $balance_rc_sender_before,
-                      after: $balance_rc_sender_after,
-                    },
-                    amount: *amount,
-                  }
-              equal:
-                args: [true, true]
+              - custom:
+                  path: ./asserts/checkSenderBalances.ts
+                  args:
+                    {
+                      balances: {
+                        before: $balance_rc_sender_before,
+                        after: $balance_rc_sender_after,
+                      },
+                      amount: *amount,
+                    }
+              - equal:
+                  args: [true, true]
 ```
 
 Interfaces:
@@ -760,7 +760,7 @@ tests: # Describe[]
                 }
               ]
           asserts:
-            equal: [$dot_price, 30]
+            - equal: [$dot_price, 30]
 
 ```
 ```typescript

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ export type RpcAction = {
   rpcs: { [key: string]: Rpc };
 }
 
-export type AsserAction = {
+export type AssertAction = {
   asserts: { [key: string]: AssertOrCustom };
 }
 
@@ -317,7 +317,7 @@ export type CustomAction = {
   customs: Custom[];
 }
 
-export type Action = ExtrinsicAction | QueryAction | AsserAction | RpcAction | CustomAction;
+export type Action = ExtrinsicAction | QueryAction | AssertAction | RpcAction | CustomAction;
 ```
 
 ### Extrinsic

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -1,5 +1,4 @@
 const chai = require('chai');
-var should = require('chai').should();
 import { Assert, Custom, AssertOrCustom } from './interfaces';
 import { customBuilder } from './custom';
 import { addConsoleGroupEnd, parseArgs } from './utils';
@@ -43,12 +42,13 @@ const runAssert = async (context, key: string, assert: AssertOrCustom) => {
 };
 
 export const assertsBuilder = async (
-  context,
-  asserts: { [key: string]: AssertOrCustom }
+    context,
+    asserts: AssertOrCustom[]
 ) => {
-  for (let key of Object.keys(asserts)) {
+  for (const assert of asserts) {
+    const key = Object.keys(assert)[0]; // Assume object with single property (key)
     if (isRegisteredAssert(key)) {
-      await runAssert(context, key, asserts[key]);
+      await runAssert(context, key, assert[key]);
     } else {
       console.log(`\n⚠️  the assert type '${key}' is not implemented`);
       process.exit(1);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -231,10 +231,11 @@ export const INTERFACE: { [key: string]: Interface } = {
     instance: YAMLSeq,
   },
   asserts: {
-    instance: YAMLMap,
+    instance: YAMLSeq,
     attributes: {
       equal: false,
       isSome: false,
+      isNone: false,
       balanceDecreased: false,
       balanceIncreased: false,
       assetsDecreased: false,
@@ -249,6 +250,12 @@ export const INTERFACE: { [key: string]: Interface } = {
     },
   },
   isSome: {
+    instance: YAMLMap,
+    attributes: {
+      args: true,
+    },
+  },
+  isNone: {
     instance: YAMLMap,
     attributes: {
       args: true,

--- a/src/custom.ts
+++ b/src/custom.ts
@@ -20,7 +20,7 @@ export const customBuilder = async (context, custom: Custom) => {
     await customFunction.default(context, parsedArgs);
   } else {
     console.log(
-      `\n⛔ ERROR: a funcion must be default exported from the file ${path}`
+      `\n⛔ ERROR: a function must be default exported from the file ${path}`
     );
     process.exit(1);
   }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -7,7 +7,7 @@ import {
   Action,
   ExtrinsicAction,
   QueryAction,
-  AsserAction,
+  AssertAction,
   CustomAction,
 } from './interfaces';
 import { customBuilder } from './custom';
@@ -58,7 +58,7 @@ export const hookBuilder = async (context, actions: Action[]) => {
   for (let action of actions) {
     const { extrinsics } = action as ExtrinsicAction;
     const { customs } = action as CustomAction;
-    const { asserts } = action as AsserAction;
+    const { asserts } = action as AssertAction;
     const { queries } = action as QueryAction;
 
     if (customs) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -121,13 +121,13 @@ export interface It {
 export type ExtrinsicAction = { extrinsics: Extrinsic[] };
 export type QueryAction = { queries: { [key: string]: Query } };
 export type RpcAction = { rpcs: { [key: string]: Rpc } };
-export type AsserAction = { asserts: { [key: string]: AssertOrCustom } };
+export type AssertAction = { asserts: AssertOrCustom[] };
 export type CustomAction = { customs: Custom[] };
 
 export type Action =
   | ExtrinsicAction
   | QueryAction
-  | AsserAction
+  | AssertAction
   | RpcAction
   | CustomAction;
 

--- a/src/it.ts
+++ b/src/it.ts
@@ -1,6 +1,6 @@
 import {
   It,
-  AsserAction,
+  AssertAction,
   ExtrinsicAction,
   QueryAction,
   CustomAction,
@@ -24,7 +24,7 @@ export const itsBuilder = (test: It) => {
     for (let action of actions) {
       const { extrinsics } = action as ExtrinsicAction;
       const { customs } = action as CustomAction;
-      const { asserts } = action as AsserAction;
+      const { asserts } = action as AssertAction;
       const { queries } = action as QueryAction;
       const { rpcs } = action as RpcAction;
 

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -28,15 +28,9 @@ cumulus_based = true
 chain = "statemine-local"
 
   [[parachains.collators]]
-  name = "statemine-collator01"
+  name = "statemine-collator"
   command = "./bin/polkadot-parachain"
   ws_port = 9910
-  args = ["--log=xcm=trace,pallet-assets=trace"]
-
-  [[parachains.collators]]
-  name = "statemine-collator02"
-  command = "./bin/polkadot-parachain"
-  ws_port = 9911
   args = ["--log=xcm=trace,pallet-assets=trace"]
 
 [types.Header]

--- a/tests/customAssert.ts
+++ b/tests/customAssert.ts
@@ -1,0 +1,7 @@
+const chai = require('chai');
+
+const checkIs42 = async (context, ...args) => {
+  chai.assert.equal(args[0][0], 42);
+};
+
+export default checkIs42;

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -15,6 +15,7 @@ settings:
         alice_account: &relay_chain_account 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
       reserve_parachain:
         bob_account: &reserve_parachain_account '0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48'
+  decodedCalls: {}
 
 tests:
   - name: Tests
@@ -86,3 +87,28 @@ tests:
                             threshold: [10, 10]
                             value: 148,804,953
                       - name: xcmPallet.Attempted # ensure an event can be matched by name only
+
+      - name: Assert tests
+        its:
+          - name: Assert tests
+            actions:
+              - queries:
+                  balance:
+                    chain: *relay_chain
+                    pallet: system
+                    call: account
+                    args: [ *relay_chain_account ]
+              # Support multiple asserts of same type (as sequence)
+              - asserts:
+                  - equal:
+                      args: [ false, false ]
+                  - equal:
+                      args: [ 10, 10 ]
+                  - isNone:
+                      args: [ null ]
+              # Supports custom asserts
+              - asserts:
+                  - custom:
+                      path: ./customAssert.ts
+                      args: [ 42 ]
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     /* Language and Environment */
     "target": "es5",
     "lib": ["es2019"],
-    "sourceMap": true,
 
     /* Modules */
     "module": "commonjs",


### PR DESCRIPTION
- rebased to update after checker implementation
- added support for multiple asserts of the same type (key) by changing asserts from `YamlMap` to `YamlSeq`
- added tests to ensure support works list based asserts (`yarn zombienet-test -t tests -c tests/config.toml`) as well as a custom assert
- added missing isNone assert definition to checker interface definition in constants.ts
- updated the readme to used dashed list syntax