### PR TITLE
Simple value asserts

### DIFF
--- a/src/asserts/valueDecreased.ts
+++ b/src/asserts/valueDecreased.ts
@@ -1,0 +1,20 @@
+const chai = require('chai');
+var should = require('chai').should();
+const BN = require('bn.js');
+chai.use(require('chai-bn')(BN));
+
+const checkValueDecreased = async (context, ...args) => {
+    const {
+        before,
+        after,
+    } = args[0][0];
+
+    let previousValue = BigInt(before);
+    let currentValue = BigInt(after);
+
+    new BN(currentValue).should.be.a.bignumber.that.is.lessThan(
+        new BN(previousValue)
+    );
+};
+
+export default checkValueDecreased;

--- a/src/asserts/valueIncreased.ts
+++ b/src/asserts/valueIncreased.ts
@@ -1,0 +1,20 @@
+const chai = require('chai');
+var should = require('chai').should();
+const BN = require('bn.js');
+chai.use(require('chai-bn')(BN));
+
+const checkValueIncreased = async (context, ...args) => {
+    const {
+        before,
+        after
+    } = args[0][0];
+
+    let previousValue = BigInt(before);
+    let currentValue = BigInt(after);
+
+    new BN(currentValue).should.be.a.bignumber.that.is.greaterThan(
+        new BN(previousValue)
+    );
+};
+
+export default checkValueIncreased;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,8 @@ export const REGISTERED_ASSERTIONS = [
   'assetsIncreased',
   'isNone',
   'isSome',
+  'valueDecreased',
+  'valueIncreased',
 ];
 
 export const INTERFACE: { [key: string]: Interface } = {
@@ -239,6 +241,8 @@ export const INTERFACE: { [key: string]: Interface } = {
       balanceIncreased: false,
       assetsDecreased: false,
       assetsIncreased: false,
+      valueDecreased: false,
+      valueIncreased: false,
       custom: false,
     },
   },
@@ -273,6 +277,18 @@ export const INTERFACE: { [key: string]: Interface } = {
     },
   },
   assetsIncreased: {
+    instance: YAMLMap,
+    attributes: {
+      args: true,
+    },
+  },
+  valueDecreased: {
+    instance: YAMLMap,
+    attributes: {
+      args: true,
+    },
+  },
+  valueIncreased: {
     instance: YAMLMap,
     attributes: {
       args: true,

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -15,6 +15,7 @@ settings:
         alice_account: &relay_chain_account 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
       reserve_parachain:
         bob_account: &reserve_parachain_account '0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48'
+  decodedCalls: {}
 
 tests:
   - name: Tests
@@ -86,3 +87,29 @@ tests:
                             threshold: [10, 10]
                             value: 148,804,953
                       - name: xcmPallet.Attempted # ensure an event can be matched by name only
+
+      - name: Assert tests
+        its:
+          - name: Value increased/decreased assert tests
+            actions:
+              - queries:
+                  balance:
+                    chain: *relay_chain
+                    pallet: system
+                    call: account
+                    args: [ *relay_chain_account ]
+              - asserts:
+                  valueDecreased:
+                    args: [
+                      {
+                        before: 1,
+                        after: 0
+                      }
+                    ]
+                  valueIncreased:
+                    args: [
+                      {
+                        before: 0,
+                        after: 1
+                      }
+                    ]


### PR DESCRIPTION
- adds simple asserts of value increase/decrease, which allows one to perform a query and then pick out a nested value (e.g. `$balance.data.free` using #79) and then assert whether the value has increased/decreased.
- adds simple test to ensure asserts work as expected (`yarn zombienet-test -t tests -c tests/config.toml`)

I can add more realistic tests if #79 gets merged.