### PR TITLE
Add variable selectors to args

### DIFF
--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -74,9 +74,12 @@ export const assertsBuilder = async (
   context,
   asserts: { [key: string]: AssertOrCustom }
 ) => {
-  for (let key of Object.keys(asserts)) {
+  for (let [i, key] of Object.keys(asserts).entries()) {
+    // Check if key matches index (i.e. list item)
+    if (key == i.toString())
+      key = Object.keys(asserts[i])[0]; // Assume object with single property (key)
     if (isRegisteredAssert(key)) {
-      await runAssert(context, key, asserts[key]);
+      await runAssert(context, key, asserts[key] ?? asserts[i][key]);
     } else {
       console.log(`\n⚠️  the assert type '${key}' is not implemented`);
       process.exit(1);

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -74,7 +74,7 @@ export const assertsBuilder = async (
   context,
   asserts: { [key: string]: AssertOrCustom }
 ) => {
-  for (let [i, key] of Object.keys(asserts).entries()) {
+  let promises = Object.keys(asserts).map(async (key, i) => {
     // Check if key matches index (i.e. list item)
     if (key == i.toString())
       key = Object.keys(asserts[i])[0]; // Assume object with single property (key)
@@ -84,5 +84,6 @@ export const assertsBuilder = async (
       console.log(`\n⚠️  the assert type '${key}' is not implemented`);
       process.exit(1);
     }
-  }
+  });
+  await Promise.all(promises);
 };

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -30,6 +30,21 @@ export const checkQuery = (key: string, query: Query, providers) => {
     );
     process.exit(1);
   }
+
+  // Ensure pallet/call exists in query api
+  const api = providers[chain.wsPort].api;
+  if (api === undefined) {
+    console.log(`\n⛔ ERROR: no query api available for provider.`);
+    process.exit(1);
+  }
+  else if (!(pallet in api.query)) {
+    console.log(`\n⛔ ERROR: "${pallet}" pallet not found in query api.`);
+    process.exit(1);
+  }
+  else if (!(call in api.query[pallet])) {
+    console.log(`\n⛔ ERROR: "${call}" call not found for "${pallet}" pallet in query api.`);
+    process.exit(1);
+  }
 };
 
 export const sendQuery = async (context, key: string, query: Query) => {

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -1,0 +1,45 @@
+[settings]
+timeout = 1000
+
+[relaychain]
+chain = "rococo-local"
+default_command = "./bin/polkadot"
+
+[[relaychain.nodes]]
+name = "alice"
+validator = true
+ws_port = 9900
+extra_args = [ "-lparachain=debug" ]
+
+[[relaychain.nodes]]
+name = "bob"
+validator = true
+extra_args = [ "-lparachain=debug" ]
+
+[[relaychain.nodes]]
+name = "charlie"
+validator = true
+extra_args = [ "-lparachain=debug" ]
+
+[[parachains]]
+id = 1000
+add_to_genesis = true
+cumulus_based = true
+chain = "statemine-local"
+
+[[parachains.collators]]
+name = "statemine-collator01"
+command = "./bin/polkadot-parachain"
+ws_port = 9910
+args = ["--log=xcm=trace,pallet-assets=trace"]
+
+[[parachains.collators]]
+name = "statemine-collator02"
+command = "./bin/polkadot-parachain"
+ws_port = 9911
+args = ["--log=xcm=trace,pallet-assets=trace"]
+
+[types.Header]
+number = "u64"
+parent_hash = "Hash"
+post_state = "Hash"

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -76,3 +76,24 @@ tests:
                       args: [ $validators[1], 5HpG9w8EBLe5XCrbczpwq5TSXvedjrBGCwqxK1iQ7qUsSWFc ]
                   - equal:
                       args: [ $total_issuance, 12000000000033333333 ]
+
+      - name: Query tests
+        its:
+          - name: Chained query tests
+            actions:
+              - queries:
+                  babe_authorities:
+                    chain: *relay_chain
+                    pallet: babe
+                    call: authorities
+                    delay: 0
+                    args: [ ]
+                  authority_balance:
+                    chain: *relay_chain
+                    pallet: system
+                    call: account
+                    delay: 0
+                    args: [ $babe_authorities[2][0] ] # use value from previous query result
+              - asserts:
+                  - equal:
+                      args: [ $authority_balance.data.free, 1000000000000000000 ]

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -1,0 +1,78 @@
+---
+settings:
+  chains:
+    relay_chain: &relay_chain
+      wsPort: 9900
+  variables:
+    chains:
+      relay_chain:
+        alice_account: &account 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+  decodedCalls: {}
+
+tests:
+  - name: Tests
+    describes:
+      - name: Assert tests
+        its:
+          - name: Assert tests
+            actions:
+              # Support asserts by key (map)
+              - asserts:
+                  equal:
+                    args: [ true, true ]
+                  isNone:
+                    args: [ null ]
+              # Support multiple asserts of same type as list
+              - asserts:
+                  - equal:
+                      args: [ false, false ]
+                  - equal:
+                      args: [ 10, 10 ]
+          - name: Args tests
+            actions:
+              - queries:
+                  authorities:
+                    chain: *relay_chain
+                    pallet: babe
+                    call: authorities
+                    delay: 0
+                    args: [ ]
+                  epoch_config:
+                    chain: *relay_chain
+                    pallet: babe
+                    call: epochConfig
+                    delay: 0
+                    args: [ ]
+                  balance:
+                    chain: *relay_chain
+                    pallet: system
+                    call: account
+                    delay: 0
+                    args: [ *account ]
+                  total_issuance:
+                    chain: *relay_chain
+                    pallet: balances
+                    call: totalIssuance
+                    delay: 0
+                    args: [ ]
+                  validators:
+                    chain: *relay_chain
+                    pallet: session
+                    call: validators
+                    delay: 0
+                    args: [ ]
+              - asserts:
+                  - equal:
+                      args: [ $authorities[2][0], '0x90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22' ]
+                  - equal:
+                      args: [ $epoch_config.value.c[1], 4 ]
+                  - equal:
+                      args: [ $balance.data.free, 1000000000000000000 ]
+                  - equal:
+                      args: [ $balance.providers, 1 ]
+                  - equal:
+                      args: [ $validators[0], 5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY ]
+                  - equal:
+                      args: [ $validators[1], 5HpG9w8EBLe5XCrbczpwq5TSXvedjrBGCwqxK1iQ7qUsSWFc ]
+                  - equal:
+                      args: [ $total_issuance, 12000000000033333333 ]


### PR DESCRIPTION
- add variable selectors to args, allowing argument value to be resolved from a nested value within a variable
- support indexing [] within argument variable selectors
- add pallet/call query checks (discovered an unhandled error scenario when I misspelled a pallet)
- support multiple aserts of same type (list/map) to simpifly test structure which makes use of same assert type multiple times
- run asserts in parallel to speed up runs
- run queries in parallel where possible to speed up runs (provided no query arguments reference variables)
- tests
  - add assert & variable tests
  - add query test which ensures query chaining (value from one result fed into argument of next)