### PR TITLE
feat: support additional keypair types

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -114,6 +114,7 @@ export const INTERFACE: { [key: string]: Interface } = {
     attributes: {
       chain: true,
       signer: true,
+      keyPairType: false,
       pallet: true,
       call: true,
       args: true,
@@ -156,6 +157,9 @@ export const INTERFACE: { [key: string]: Interface } = {
     type: 'boolean'
   },
   signer: {
+    type: 'string'
+  },
+  keyPairType: {
     type: 'string'
   },
   delay: {

--- a/src/extrinsics.ts
+++ b/src/extrinsics.ts
@@ -19,7 +19,7 @@ export const sendExtrinsic = async (
     try {
       let providers = context.providers;
 
-      const { chain, delay, signer, pallet, call, args, events } = extrinsic;
+      const { chain, delay, signer, keyPairType, pallet, call, args, events } = extrinsic;
 
       await sleep(delay ? delay : 0);
 
@@ -37,7 +37,7 @@ export const sendExtrinsic = async (
       );
 
       let api = providers[chain.wsPort].api;
-      let wallet = await getWallet(signer);
+      let wallet = await getWallet(signer, keyPairType);
       let nonce = await api.rpc.system.accountNextIndex(wallet.address);
       let handler = events ? eventsHandler(context, chain, events, resolve, reject) : () => { resolve([]) }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,3 +1,5 @@
+import {KeypairType} from "@polkadot/util-crypto/types";
+
 export interface TestFile {
   name: string;
   dir: string;
@@ -64,6 +66,7 @@ export interface Call {
 
 export interface Extrinsic extends Call {
   signer: string;
+  keyPairType?: KeypairType;
   delay?: number;
   events: Event[];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,7 @@ import {
   Range,
 } from './interfaces';
 import { KeyringPair } from '@polkadot/keyring/types';
+import { KeypairType } from "@polkadot/util-crypto/types";
 
 export const getTestFiles = (path): TestFile[] => {
 
@@ -108,13 +109,14 @@ export const getPaymentInfoForExtrinsic = async (
   const { signer } = extrinsic;
 
   let dispatchable = buildDispatchable(context, extrinsic);
-  let wallet = await getWallet(signer);
+  let wallet = await getWallet(signer, extrinsic.keyPairType);
 
   return await dispatchable.paymentInfo(wallet);
 };
 
 export const getWallet = async (
-  uri: string
+  uri: string,
+  type?: KeypairType
 ): Promise<
   | KeyringPair
   | {
@@ -122,9 +124,9 @@ export const getWallet = async (
       addressRaw: Uint8Array;
     }
 > => {
-  if (uri.substring(0, 2) === '//') {
+  if (uri.substring(0, 2) === '//' || uri.substring(0, 2) === '0x' ) {
     await cryptoWaitReady();
-    const keyring = new Keyring({ type: 'sr25519' });
+    const keyring = new Keyring({ type: type ?? 'sr25519' });
     return keyring.addFromUri(uri);
   } else {
     return { address: uri, addressRaw: decodeAddress(uri) };


### PR DESCRIPTION
Enables optional support for other keypair types when submitting an extrinsic, required to use 'ethereum' for Moonbeam. 

The quickest way to get this working was to add an additional optional attribute to the Extrinsic type, but there might be a more elegant solution.

Example usage:
```
- chain: *evm_parachain
    sudo: true
    signer: "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133" # PrivKey from https://github.com/PureStake/moonbeam#prefunded-development-addresses
    keyPairType: ethereum
    pallet: assetManager
    call: registerForeignAsset
```

The available types can be found at https://github.com/polkadot-js/common/blob/7611ec8b014780499a5a1d3b89cf76077d478dea/packages/util-crypto/src/types.ts#L17