### PR TITLE
Replace transfer with transferAllowDeath

### DIFF
--- a/examples/statemine/0_xcm/3_force_hrmp-open-channels.yml
+++ b/examples/statemine/0_xcm/3_force_hrmp-open-channels.yml
@@ -42,7 +42,7 @@ tests:
               - chain: *relay_chain
                 signer: *rc_signer
                 pallet: balances
-                call: transfer
+                call: transferAllowDeath
                 args: [
                   *pp_sovereign, # destination
                   *amount, # value
@@ -56,7 +56,7 @@ tests:
               - chain: *relay_chain
                 signer: *rc_signer
                 pallet: balances
-                call: transfer
+                call: transferAllowDeath
                 args: [
                   *ap_sovereign, # destination
                   *amount, # value

--- a/examples/statemint/0_xcm/3_force_hrmp-open-channels.yml
+++ b/examples/statemint/0_xcm/3_force_hrmp-open-channels.yml
@@ -42,7 +42,7 @@ tests:
             - chain: *relay_chain
               signer: *rc_signer
               pallet: balances
-              call: transfer
+              call: transferAllowDeath
               args: [
                 *pp_sovereign, # destination
                 *amount, # value
@@ -56,7 +56,7 @@ tests:
             - chain: *relay_chain
               signer: *rc_signer
               pallet: balances
-              call: transfer
+              call: transferAllowDeath
               args: [
                 *ap_sovereign, # destination
                 *amount, # value


### PR DESCRIPTION
Small change, in the integration-tests examples replace the call `transfer` with the call `transferAllowDeath` as trasnfer is `deprecated`: Remove deprecated pallet_balances's set_balance_deprecated and transfer dispatchables: https://github.com/paritytech/polkadot-sdk/pull/1226